### PR TITLE
Custom action flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,31 @@ metatable()
 A behavior that expects to be called with a selection an array of objects
 of data. Emits events:
 
-* rowfocus: a row is focused. returns the object and the index
-* change: a row is changed. returns the object and the index
+* `change`: a row is changed. returns the object and the index
+* `rowfocus`: a row is focused. returns the object and the index
+* `renameprompt`: Column is about to be renamed. Useful for passing in a custom workflow for submitting a value that overrides the default. usage:
+
+``` js
+.on('renameprompt', function(d, process) {
+    // Prevent the default prompt.
+    this.preventprompt('rename');
+
+    // Do it your own way
+    var newname = prompt('Rename column to:');
+
+    // Continue internally by passing the new name and current one.
+    if (newname) process(newname, d);
+});
+```
+
+* `deleteprompt`: Column is about to be deleted. Useful for passing in a custom workflow for delete confirmation to override the default one. usage:
+
+``` js
+.on('deleteprompt', function(d, process) {
+    // Prevent the default prompt.
+    this.preventprompt('delete');
+
+    // Do it your own way
+    if (confirm('Are you sure you want to delete ' + d + '?')) process(d);
+});
+```

--- a/index.html
+++ b/index.html
@@ -48,7 +48,21 @@
           data[i] = d;
           d3.select('#json')
               .property('value', JSON.stringify(data, null, 2));
-      }).on('rowfocus', function(d, i) {}));
+            }).on('rowfocus', function(d, i) {}).on('renameprompt', function(d, okRename) {
+
+                // Listening to `renameprompt`, you
+                // can pass in your own value submit flow.
+                this.preventprompt('rename');
+                var newname = prompt('Rename column to:');
+                if (newname) okRename(newname, d);
+
+              }).on('deleteprompt', function(d, okDelete) {
+
+                // Listening to `deleteprompt`, you
+                // can pass in your own confirmation flow.
+                this.preventprompt('delete');
+                if (confirm('Are you sure you want to delete ' + d + '?')) okDelete(d);
+            }));
   </script>
 </body>
 </html>


### PR DESCRIPTION
This commit adds two weird events `renameprompt` and `deleteprompt`. The goal here is to override the default control flow for these actions (confirm(delete?) prompt(name?)) in order to pass in a custom workflow. Documentation of its usage is in the README.

cc/ @tmcw 
