### PR TITLE
Multi-line inputs (using textarea).

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,11 @@
 <meta charset=utf-8 />
 <meta name='viewport' content='initial-scale=1.0 maximum-scale=1.0'>
 <link href='//www.mapbox.com/base/latest/base.css' rel='stylesheet' />
+<style>
+textarea {
+  white-space: nowrap;
+}
+</style>
 <title>d3-metatable | MapBox</title>
 </head>
 <body>
@@ -24,11 +29,12 @@
           data.push({
               v1: Math.random(),
               v2: 'foo',
-              v3: 'foo bar' + Math.random()
+              v3: 'foo bar' + Math.random(),
+              v4: 'foo\nbar'
           });
       } else if (Math.random() > 0.5) {
           data.push({
-              v2: 'foo',
+              v2: '<b>foo</b>',
               v3: 'foo bar' + Math.random(),
               v4: 'foo bar' + Math.random()
           });

--- a/metatable.js
+++ b/metatable.js
@@ -106,8 +106,7 @@ function metatable() {
 
                 td.enter()
                     .append('td')
-                    .append('input')
-                    .attr('type', 'text')
+                    .append('textarea')
                     .attr('field', String);
 
                 td.exit().remove();
@@ -126,7 +125,7 @@ function metatable() {
 
                 function completeDelete(name) {
                     keyset.remove(name);
-                    tr.selectAll('input')
+                    tr.selectAll('textarea')
                         .data(function(d, i) {
                             var map = d3.map(d);
                             map.remove(name);
@@ -157,7 +156,7 @@ function metatable() {
                 function completeRename(value, name) {
                     keyset.add(value);
                     keyset.remove(name);
-                    tr.selectAll('input')
+                    tr.selectAll('textarea')
                         .data(function(d, i) {
                             var map = d3.map(d);
                             map.set(value, map.get(name));
@@ -191,7 +190,7 @@ function metatable() {
                         }, {});
                 }
 
-                tr.selectAll('input')
+                tr.selectAll('textarea')
                     .data(function(d, i) {
                         return d3.range(keys.length).map(function() {
                             return {


### PR DESCRIPTION
An alternative to my previous pull request. 

Using the `contenteditable` attribute branch of this as the dependency in geojson.io broke pretty spectacularly. Using `textarea` is a little less elegant, but works well.

Fixes #10
