### PR TITLE
Define options as empty object if it's undefined

### DIFF
--- a/metatable.js
+++ b/metatable.js
@@ -8,6 +8,8 @@ function metatable(options) {
     var event = d3.dispatch('change', 'rowfocus', 'renameprompt', 'deleteprompt', 'preventprompt');
     var _renamePrompt, _deletePrompt;
 
+    options = options || {};
+
     var config = {
         newCol: options.newCol || true,
         renameCol: options.renameCol || true,


### PR DESCRIPTION
On my machine, the [demo page](http://mapbox.github.io/d3-metatable/) errors out with a `metatable.js:12 Uncaught TypeError: Cannot read property 'newCol' of undefined`.  This small patch makes sure options is a blank object if it is undefined.
